### PR TITLE
Allows overriding default scopes on instantiation

### DIFF
--- a/src/Provider/Shopify.php
+++ b/src/Provider/Shopify.php
@@ -13,6 +13,16 @@ class Shopify extends AbstractProvider
      * @var string
      */
     public $store = '';
+    
+    /**
+     * The default scopes.
+     *
+     * @var string
+     */
+    protected $defaultScopes = [
+        'read_orders',
+        'read_products'
+    ];
 
     /**
      * @param array $options
@@ -78,10 +88,7 @@ class Shopify extends AbstractProvider
      */
     protected function getDefaultScopes()
     {
-        return [
-            'read_orders',
-            'read_products'
-        ];
+        return $this->defaultScopes;
     }
 
     /**


### PR DESCRIPTION
Simple, non-breaking change to allow overriding default scopes on instantiation, by passing `'defaultScopes' => ['write_orders', 'another_scope']` into the `$options` param, otherwise we have to extend this class just to change them.